### PR TITLE
Fix global require in unit test

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2,15 +2,16 @@ const fs = require('fs');
 const path = require('path');
 const simulate = require('miniprogram-simulate');
 
+let def;
+global.Page = (obj) => { def = obj; };
+require('../miniprogram/pages/index/index');
+
 test('index page navigation', () => {
-  let def;
-  global.Page = (obj) => { def = obj; };
-  require('../miniprogram/pages/index/index.js');
   wx.navigateTo = jest.fn();
 
   const template = fs.readFileSync(
     path.resolve(__dirname, '../miniprogram/pages/index/index.wxml'),
-    'utf8'
+    'utf8',
   );
   const id = simulate.load({ template, methods: { handleStart: def.handleStart } });
   const page = simulate.render(id);


### PR DESCRIPTION
## Summary
- load the page under test before the test block
- remove file extension for the `require`

## Testing
- `npm test --silent`
- `npx eslint __tests__/index.test.js -f unix`


------
https://chatgpt.com/codex/tasks/task_e_6868856a2f2483208bc88cdd1aaca8a1