### PR TITLE
Fix lint for index test

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -5,12 +5,13 @@ const simulate = require('miniprogram-simulate');
 test('index page navigation', () => {
   let def;
   global.Page = (obj) => { def = obj; };
-  require('../miniprogram/pages/index/index.js');
+  // eslint-disable-next-line global-require
+  require('../miniprogram/pages/index/index');
   wx.navigateTo = jest.fn();
 
   const template = fs.readFileSync(
     path.resolve(__dirname, '../miniprogram/pages/index/index.wxml'),
-    'utf8'
+    'utf8',
   );
   const id = simulate.load({ template, methods: { handleStart: def.handleStart } });
   const page = simulate.render(id);


### PR DESCRIPTION
## Summary
- fix ESLint warnings in index.test.js

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868be5714808320b38ca177f82ad37a