### PR TITLE
Ensure home page included in coverage

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -5,12 +5,10 @@ const simulate = require('miniprogram-simulate');
 let def;
 global.Page = (obj) => { def = obj; };
 require('../miniprogram/pages/index/index');
+global.Page = () => {};
+require('../miniprogram/pages/home/home');
 
 test('index page navigation', () => {
-  let def;
-  global.Page = (obj) => { def = obj; };
-  // eslint-disable-next-line global-require
-  require('../miniprogram/pages/index/index');
   wx.navigateTo = jest.fn();
 
   const template = fs.readFileSync(


### PR DESCRIPTION
## Summary
- load `home.js` in tests to track coverage
- avoid clobbering the index page export while loading `home.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c2a910a88320946d93495483f0f5