### PR TITLE
Fix Page stubs cleanup in index test

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -3,6 +3,17 @@ const path = require('path');
 const simulate = require('miniprogram-simulate');
 
 test('index page navigation', () => {
+  const originalPage = global.Page;
+  let def;
+  global.Page = (obj) => { def = obj; };
+  // eslint-disable-next-line global-require
+  require('../miniprogram/pages/index/index');
+
+  global.Page = () => {};
+  // eslint-disable-next-line global-require
+  require('../miniprogram/pages/home/home');
+
+  const originalNavigate = wx.navigateTo;
   wx.navigateTo = jest.fn();
 
   const template = fs.readFileSync(
@@ -13,5 +24,9 @@ test('index page navigation', () => {
   const page = simulate.render(id);
   page.attach(document.createElement('parent'));
   page.instance.handleStart();
+
   expect(wx.navigateTo).toHaveBeenCalledWith({ url: '/pages/home/home' });
+
+  wx.navigateTo = originalNavigate;
+  global.Page = originalPage;
 });


### PR DESCRIPTION
## Summary
- restore `global.Page` stub logic in `index.test.js`
- preserve original `Page` and `wx.navigateTo` and restore them after each test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c7ffd5648320b9f7c2fcdd4fb844