### PR TITLE
Improve tap event simulation

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,8 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 const simulate = require('miniprogram-simulate');
+const exparser = require('miniprogram-exparser');
 
-test('index page navigation', () => {
+let def;
+
+beforeAll(() => {
+  global.Page = (obj) => { def = obj; };
+  require('../miniprogram/pages/index/index');
+  global.Page = () => {};
+  require('../miniprogram/pages/home/home');
+});
+
+afterAll(() => {
+  global.Page = undefined;
+});
+
+test('index page navigation', async () => {
   wx.navigateTo = jest.fn();
 
   const template = fs.readFileSync(
@@ -12,6 +26,10 @@ test('index page navigation', () => {
   const id = simulate.load({ template, methods: { handleStart: def.handleStart } });
   const page = simulate.render(id);
   page.attach(document.createElement('parent'));
-  page.instance.handleStart();
+
+  const button = page.dom.querySelector('wx-button');
+  exparser.triggerEvent(button.__wxElement, 'tap');
+  await simulate.sleep(0);
+
   expect(wx.navigateTo).toHaveBeenCalledWith({ url: '/pages/home/home' });
 });


### PR DESCRIPTION
## Summary
- trigger navigation by dispatching a `tap` event with `exparser.triggerEvent`
- assert navigation call after the event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c8039548832083353d026fdbd025