### PR TITLE
Resolve lint warnings and add eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+miniprogram/wxcharts.js
+miniprogram/miniprogram_npm/
+coverage/

--- a/__tests__/admin.test.js
+++ b/__tests__/admin.test.js
@@ -7,8 +7,10 @@ let originalPage;
 beforeAll(() => {
   originalPage = global.Page;
   global.Page = (obj) => { auditDef = obj; };
+  // eslint-disable-next-line global-require
   require('../miniprogram/pages/admin/audit/audit');
   global.Page = (obj) => { statsDef = obj; };
+  // eslint-disable-next-line global-require
   require('../miniprogram/pages/admin/stats/stats');
 });
 
@@ -17,8 +19,12 @@ afterAll(() => {
 });
 
 const logsData = [
-  { _id: '1', userId: 'u1', type: 'labor', minutes: 10, status: 'pending' },
-  { _id: '2', userId: 'u1', type: 'volunteer', minutes: 20, status: 'approved' },
+  {
+    _id: '1', userId: 'u1', type: 'labor', minutes: 10, status: 'pending',
+  },
+  {
+    _id: '2', userId: 'u1', type: 'volunteer', minutes: 20, status: 'approved',
+  },
 ];
 const usersData = { u1: { totalPoints: 0 } };
 
@@ -32,6 +38,7 @@ wx.cloud = {
   }),
   callFunction: jest.fn(async ({ name, data }) => {
     if (name === 'approveLog') {
+      // eslint-disable-next-line no-underscore-dangle
       const log = logsData.find((l) => l._id === data.logId);
       log.status = 'approved';
       const pts = log.type === 'volunteer' ? log.minutes * 2 : log.minutes;

--- a/__tests__/logTime.test.js
+++ b/__tests__/logTime.test.js
@@ -6,6 +6,7 @@ let originalPage;
 beforeAll(() => {
   originalPage = global.Page;
   global.Page = (obj) => { def = obj; };
+  // eslint-disable-next-line global-require
   require('../miniprogram/pages/log-time/log-time');
 });
 

--- a/cloudfunctions/approveLog/index.js
+++ b/cloudfunctions/approveLog/index.js
@@ -8,7 +8,7 @@ const logs = db.collection('Logs');
 const users = db.collection('Users');
 const _ = db.command;
 
-exports.main = async (event, context) => {
+exports.main = async (event) => {
   const { OPENID } = cloud.getWXContext();
   if (!ADMIN_OPENIDS.includes(OPENID)) {
     throw new Error('unauthorized');

--- a/cloudfunctions/getStats/index.js
+++ b/cloudfunctions/getStats/index.js
@@ -7,7 +7,7 @@ const db = cloud.database();
 const logs = db.collection('Logs');
 const _ = db.command;
 
-exports.main = async (event, context) => {
+exports.main = async () => {
   const { OPENID } = cloud.getWXContext();
   if (!ADMIN_OPENIDS.includes(OPENID)) {
     throw new Error('unauthorized');

--- a/miniprogram/pages/admin/audit/audit.js
+++ b/miniprogram/pages/admin/audit/audit.js
@@ -3,7 +3,7 @@ const { ADMIN_OPENIDS } = require('../../../../cloudfunctions/common/constants')
 Page({
   data: { logs: [] },
   async onShow() {
-    const openid = getApp().globalData.openid;
+    const { openid } = getApp().globalData;
     if (!ADMIN_OPENIDS.includes(openid)) {
       wx.navigateBack();
       return;
@@ -15,6 +15,7 @@ Page({
   async handleApprove(e) {
     const { id } = e.currentTarget.dataset;
     await wx.cloud.callFunction({ name: 'approveLog', data: { logId: id } });
+    // eslint-disable-next-line no-underscore-dangle
     this.setData({ logs: this.data.logs.filter((log) => log._id !== id) });
   },
 });

--- a/miniprogram/pages/admin/stats/stats.js
+++ b/miniprogram/pages/admin/stats/stats.js
@@ -6,14 +6,14 @@ Page({
     return this.refresh();
   },
   async refresh() {
-    const openid = getApp().globalData.openid;
+    const { openid } = getApp().globalData;
     if (!ADMIN_OPENIDS.includes(openid)) {
       wx.navigateBack();
       return;
     }
     const res = await wx.cloud.callFunction({ name: 'getStats' });
     const { laborMinutes, volunteerMinutes } = res.result;
-    // eslint-disable-next-line no-new
+    // eslint-disable-next-line no-new, new-cap
     new wxCharts({
       canvasId: 'pieCanvas',
       type: 'pie',
@@ -24,6 +24,8 @@ Page({
       width: 300,
       height: 200,
     });
+    // returning result makes it easier for tests to assert
+    // eslint-disable-next-line consistent-return
     return res;
   },
 });


### PR DESCRIPTION
## Summary
- add `.eslintignore` to skip third-party code
- fix lint errors in tests and cloud functions
- ensure admin pages follow ESLint rules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868f922ce5c832083dc50449064a72b