### PR TITLE
Add profile page and navigation

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -2,6 +2,7 @@
   "pages": [
     "pages/index/index",
     "pages/home/home",
+    "pages/profile/profile",
     "pages/log-time/log-time",
     "pages/admin/audit/audit",
     "pages/admin/stats/stats"

--- a/miniprogram/pages/home/home.js
+++ b/miniprogram/pages/home/home.js
@@ -1,1 +1,8 @@
-Page({});
+Page({
+  goProfile() {
+    wx.navigateTo({ url: '/pages/profile/profile' });
+  },
+  goLogTime() {
+    wx.navigateTo({ url: '/pages/log-time/log-time' });
+  },
+});

--- a/miniprogram/pages/home/home.json
+++ b/miniprogram/pages/home/home.json
@@ -1,3 +1,7 @@
 {
-  "navigationBarTitleText": "首页"
+  "navigationBarTitleText": "首页",
+  "usingComponents": {
+    "van-cell": "@vant/weapp/cell/index",
+    "van-cell-group": "@vant/weapp/cell-group/index"
+  }
 }

--- a/miniprogram/pages/home/home.wxml
+++ b/miniprogram/pages/home/home.wxml
@@ -1,3 +1,6 @@
 <view class="container">
-  <text>欢迎使用</text>
+  <van-cell-group>
+    <van-cell title="个人信息" is-link bindtap="goProfile" />
+    <van-cell title="时长提交" is-link bindtap="goLogTime" />
+  </van-cell-group>
 </view>

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -1,4 +1,4 @@
 <view class="container">
   <text class="title">善水书院积分系统</text>
-  <button bindtap="handleStart">开始使用</button>
+  <button class="start-btn" bindtap="handleStart">开始使用</button>
 </view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -6,3 +6,10 @@
   font-size: 36rpx;
   margin-bottom: 30rpx;
 }
+
+.start-btn {
+  width: 300rpx;
+  margin: 0 auto;
+  background-color: #07c160;
+  color: #fff;
+}

--- a/miniprogram/pages/profile/profile.js
+++ b/miniprogram/pages/profile/profile.js
@@ -1,0 +1,16 @@
+Page({
+  data: {
+    name: '',
+    studentId: '',
+  },
+  onNameChange(e) {
+    this.setData({ name: e.detail });
+  },
+  onIdChange(e) {
+    this.setData({ studentId: e.detail });
+  },
+  handleSubmit() {
+    wx.showToast({ title: '保存成功', icon: 'success' });
+    wx.navigateBack();
+  },
+});

--- a/miniprogram/pages/profile/profile.json
+++ b/miniprogram/pages/profile/profile.json
@@ -1,0 +1,7 @@
+{
+  "navigationBarTitleText": "个人信息",
+  "usingComponents": {
+    "van-field": "@vant/weapp/field/index",
+    "van-button": "@vant/weapp/button/index"
+  }
+}

--- a/miniprogram/pages/profile/profile.wxml
+++ b/miniprogram/pages/profile/profile.wxml
@@ -1,0 +1,7 @@
+<form bindsubmit="handleSubmit">
+  <van-field label="姓名" value="{{name}}" bind:input="onNameChange" placeholder="请输入姓名" />
+  <van-field label="学号" value="{{studentId}}" bind:input="onIdChange" placeholder="请输入学号" />
+  <view class="btn-wrap">
+    <van-button block type="info" formType="submit">保存</van-button>
+  </view>
+</form>

--- a/miniprogram/pages/profile/profile.wxss
+++ b/miniprogram/pages/profile/profile.wxss
@@ -1,0 +1,3 @@
+.btn-wrap {
+  margin: 20rpx;
+}


### PR DESCRIPTION
## Summary
- enhance home with links to profile and time logging
- create new profile page using Vant components
- style index page and button
- register new page in `app.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686906b753508320ad8b2e673bcfd51e