### PR TITLE
Fix constants import for admin pages

### DIFF
--- a/__tests__/admin.test.js
+++ b/__tests__/admin.test.js
@@ -1,5 +1,5 @@
 const simulate = require('miniprogram-simulate');
-const { LOG_STATUS, LOG_TYPES, VOLUNTEER_POINTS_MULTIPLIER } = require('../cloudfunctions/common/constants');
+const { LOG_STATUS, LOG_TYPES, VOLUNTEER_POINTS_MULTIPLIER } = require('../miniprogram/common/constants');
 
 let auditDef;
 let statsDef;

--- a/__tests__/logTime.test.js
+++ b/__tests__/logTime.test.js
@@ -1,5 +1,5 @@
 const simulate = require('miniprogram-simulate');
-const { LOG_TYPES } = require('../cloudfunctions/common/constants');
+const { LOG_TYPES } = require('../miniprogram/common/constants');
 
 let def;
 let originalPage;

--- a/miniprogram/common/constants.js
+++ b/miniprogram/common/constants.js
@@ -1,0 +1,12 @@
+module.exports = {
+  ADMIN_OPENIDS: ['admin_openid'],
+  LOG_STATUS: {
+    PENDING: 'pending',
+    APPROVED: 'approved',
+  },
+  LOG_TYPES: {
+    LABOR: 'labor',
+    VOLUNTEER: 'volunteer',
+  },
+  VOLUNTEER_POINTS_MULTIPLIER: 2,
+};

--- a/miniprogram/pages/admin/audit/audit.js
+++ b/miniprogram/pages/admin/audit/audit.js
@@ -1,4 +1,4 @@
-const { ADMIN_OPENIDS, LOG_STATUS } = require('../../../../cloudfunctions/common/constants');
+const { ADMIN_OPENIDS, LOG_STATUS } = require('../../../common/constants');
 
 Page({
   data: { logs: [] },

--- a/miniprogram/pages/admin/stats/stats.js
+++ b/miniprogram/pages/admin/stats/stats.js
@@ -1,4 +1,4 @@
-const { ADMIN_OPENIDS } = require('../../../../cloudfunctions/common/constants');
+const { ADMIN_OPENIDS } = require('../../../common/constants');
 const wxCharts = require('../../../wxcharts');
 
 Page({


### PR DESCRIPTION
## Summary
- ensure constants file is available in the miniprogram
- update admin pages to import constants from the new location
- update tests for new constants path

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691115db4083208be729ae226893ae