### PR TITLE
Centralize constant definitions

### DIFF
--- a/cloudfunctions/common/constants.js
+++ b/cloudfunctions/common/constants.js
@@ -1,12 +1,1 @@
-module.exports = {
-  ADMIN_OPENIDS: ['admin_openid'],
-  LOG_STATUS: {
-    PENDING: 'pending',
-    APPROVED: 'approved',
-  },
-  LOG_TYPES: {
-    LABOR: 'labor',
-    VOLUNTEER: 'volunteer',
-  },
-  VOLUNTEER_POINTS_MULTIPLIER: 2,
-};
+module.exports = require('../../common/constants');

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,0 +1,12 @@
+module.exports = {
+  ADMIN_OPENIDS: ['admin_openid'],
+  LOG_STATUS: {
+    PENDING: 'pending',
+    APPROVED: 'approved',
+  },
+  LOG_TYPES: {
+    LABOR: 'labor',
+    VOLUNTEER: 'volunteer',
+  },
+  VOLUNTEER_POINTS_MULTIPLIER: 2,
+};

--- a/miniprogram/common/constants.js
+++ b/miniprogram/common/constants.js
@@ -1,12 +1,1 @@
-module.exports = {
-  ADMIN_OPENIDS: ['admin_openid'],
-  LOG_STATUS: {
-    PENDING: 'pending',
-    APPROVED: 'approved',
-  },
-  LOG_TYPES: {
-    LABOR: 'labor',
-    VOLUNTEER: 'volunteer',
-  },
-  VOLUNTEER_POINTS_MULTIPLIER: 2,
-};
+module.exports = require('../../common/constants');


### PR DESCRIPTION
## Summary
- extract constants into `common/constants.js`
- re-export shared constants from cloud functions and the mini program

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691591c24083208d287a1d2c7d6cc9