### PR TITLE
Fix constants path for miniprogram

### DIFF
--- a/__tests__/admin.test.js
+++ b/__tests__/admin.test.js
@@ -1,5 +1,6 @@
 const simulate = require('miniprogram-simulate');
-const { LOG_STATUS, LOG_TYPES, VOLUNTEER_POINTS_MULTIPLIER } = require('../miniprogram/common/constants');
+const { LOG_STATUS } = require('../miniprogram/common/constants');
+const { LOG_TYPES, VOLUNTEER_POINTS_MULTIPLIER } = require('../common/constants');
 
 let auditDef;
 let statsDef;
@@ -52,10 +53,9 @@ wx.cloud = {
       // eslint-disable-next-line no-underscore-dangle
       const log = logsData.find((l) => l._id === data.logId);
       log.status = LOG_STATUS.APPROVED;
-      const pts =
-        log.type === LOG_TYPES.VOLUNTEER
-          ? log.minutes * VOLUNTEER_POINTS_MULTIPLIER
-          : log.minutes;
+      const pts = log.type === LOG_TYPES.VOLUNTEER
+        ? log.minutes * VOLUNTEER_POINTS_MULTIPLIER
+        : log.minutes;
       usersData[log.userId].totalPoints += pts;
       return { result: { ok: true } };
     }

--- a/__tests__/history.test.js
+++ b/__tests__/history.test.js
@@ -1,5 +1,6 @@
 const simulate = require('miniprogram-simulate');
-const { LOG_TYPES, LOG_STATUS } = require('../miniprogram/common/constants');
+const { LOG_STATUS } = require('../miniprogram/common/constants');
+const { LOG_TYPES } = require('../common/constants');
 
 let def;
 let originalPage;
@@ -22,7 +23,9 @@ wx.cloud = {
       where: () => ({
         get: jest.fn().mockResolvedValue({
           data: [
-            { _id: '1', type: LOG_TYPES.LABOR, minutes: 10, status: LOG_STATUS.APPROVED, remark: 'r1' },
+            {
+              _id: '1', type: LOG_TYPES.LABOR, minutes: 10, status: LOG_STATUS.APPROVED, remark: 'r1',
+            },
           ],
         }),
       }),

--- a/__tests__/logTime.test.js
+++ b/__tests__/logTime.test.js
@@ -1,5 +1,5 @@
 const simulate = require('miniprogram-simulate');
-const { LOG_TYPES } = require('../miniprogram/common/constants');
+const { LOG_TYPES } = require('../common/constants');
 
 let def;
 let originalPage;

--- a/cloudfunctions/approveLog/index.js
+++ b/cloudfunctions/approveLog/index.js
@@ -1,5 +1,7 @@
 const cloud = require('wx-server-sdk');
-const { ADMIN_OPENIDS, LOG_STATUS, LOG_TYPES, VOLUNTEER_POINTS_MULTIPLIER } = require('../common/constants');
+const {
+  ADMIN_OPENIDS, LOG_STATUS, LOG_TYPES, VOLUNTEER_POINTS_MULTIPLIER,
+} = require('../common/constants');
 
 cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
 
@@ -20,10 +22,9 @@ exports.main = async (event) => {
     return { ok: false };
   }
   await logs.doc(logId).update({ data: { status: LOG_STATUS.APPROVED } });
-  const points =
-    log.type === LOG_TYPES.VOLUNTEER
-      ? log.minutes * VOLUNTEER_POINTS_MULTIPLIER
-      : log.minutes;
+  const points = log.type === LOG_TYPES.VOLUNTEER
+    ? log.minutes * VOLUNTEER_POINTS_MULTIPLIER
+    : log.minutes;
   await users.doc(log.userId).update({ data: { totalPoints: _.inc(points) } });
   return { ok: true, points };
 };

--- a/miniprogram/common/constants.js
+++ b/miniprogram/common/constants.js
@@ -1,1 +1,7 @@
-module.exports = require('../../common/constants');
+module.exports = {
+  ADMIN_OPENIDS: ['admin_openid'],
+  LOG_STATUS: {
+    PENDING: 'pending',
+    APPROVED: 'approved',
+  },
+};

--- a/miniprogram/pages/admin/audit/audit.js
+++ b/miniprogram/pages/admin/audit/audit.js
@@ -1,4 +1,4 @@
-const { ADMIN_OPENIDS, LOG_STATUS } = require('../../../common/constants');
+const { ADMIN_OPENIDS, LOG_STATUS } = require('../../common/constants');
 
 Page({
   data: { logs: [] },

--- a/miniprogram/pages/admin/stats/stats.js
+++ b/miniprogram/pages/admin/stats/stats.js
@@ -1,4 +1,4 @@
-const { ADMIN_OPENIDS } = require('../../../common/constants');
+const { ADMIN_OPENIDS } = require('../../common/constants');
 const wxCharts = require('../../../wxcharts');
 
 Page({

--- a/miniprogram/pages/common/constants.js
+++ b/miniprogram/pages/common/constants.js
@@ -1,0 +1,1 @@
+module.exports = require('../../common/constants');

--- a/miniprogram/pages/history/history.js
+++ b/miniprogram/pages/history/history.js
@@ -1,5 +1,3 @@
-const { LOG_STATUS } = require('../../common/constants');
-
 Page({
   data: {
     logs: [],


### PR DESCRIPTION
## Summary
- copy limited constants to miniprogram
- update admin page imports to use new path
- adjust tests for new constants location
- lint fixes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68691e4021108320a17cd905e78d49a5