### PR TITLE
Add tap log and test

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -5,6 +5,7 @@ const exparser = require('miniprogram-exparser');
 
 let def;
 let originalPage;
+let logSpy;
 
 beforeAll(() => {
   originalPage = global.Page;
@@ -22,6 +23,7 @@ afterAll(() => {
 });
 
 test('index page navigation', async () => {
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   wx.cloud = { callFunction: jest.fn().mockResolvedValue({ result: { openid: 'o1' } }) };
   const originalNavigate = wx.navigateTo;
   wx.navigateTo = jest.fn();
@@ -39,7 +41,10 @@ test('index page navigation', async () => {
   exparser.triggerEvent(button.__wxElement, 'tap');
   await simulate.sleep(0);
 
+  expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[tap]'), expect.any(Number));
+
   expect(wx.navigateTo).toHaveBeenCalledWith({ url: '/pages/home/home' });
 
   wx.navigateTo = originalNavigate;
+  logSpy.mockRestore();
 });

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -2,6 +2,7 @@ const app = getApp();
 
 Page({
   async handleStart() {
+    console.log("[tap]", Date.now());
     try {
       const res = await wx.cloud.callFunction({ name: 'login' });
       app.globalData.openid = res.result.openid;


### PR DESCRIPTION
## Summary
- log when handleStart is tapped
- verify tap logging in tests

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d1a1822f0832080bef7c8e059f9d1