### PR TITLE
Add shop & profile pages with mock redeem logic

### DIFF
--- a/__tests__/shop.test.js
+++ b/__tests__/shop.test.js
@@ -1,0 +1,40 @@
+let mockRedeem;
+let getUser;
+let getRewards;
+
+({ mockRedeem, getUser, getRewards } = require('../miniprogram/utils/mockApi'));
+
+describe('mockRedeem', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    // reload after reset
+    // eslint-disable-next-line global-require
+    ({ mockRedeem, getUser, getRewards } = require('../miniprogram/utils/mockApi'));
+    global.wx = {};
+  });
+
+  test('success deducts points and stock', () => {
+    wx.showToast = jest.fn();
+    const user = getUser();
+    const rewards = getRewards();
+    const prevPoints = user.totalPoints;
+    const prevStock = rewards[0].stock;
+    const ok = mockRedeem(1);
+    expect(ok).toBe(true);
+    expect(user.totalPoints).toBe(prevPoints - rewards[0].points);
+    expect(rewards[0].stock).toBe(prevStock - 1);
+  });
+
+  test('insufficient points toast', () => {
+    wx.showToast = jest.fn();
+    const user = getUser();
+    const rewards = getRewards();
+    user.totalPoints = 0;
+    const prevStock = rewards[0].stock;
+    const ok = mockRedeem(1);
+    expect(ok).toBe(false);
+    expect(wx.showToast).toHaveBeenCalledWith({ title: '积分不足', icon: 'none' });
+    expect(user.totalPoints).toBe(0);
+    expect(rewards[0].stock).toBe(prevStock);
+  });
+});

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -2,6 +2,7 @@
   "pages": [
     "pages/index/index",
     "pages/home/home",
+    "pages/shop/shop",
     "pages/profile/profile",
     "pages/log-time/log-time",
     "pages/admin/audit/audit",

--- a/miniprogram/mock/rewards.json
+++ b/miniprogram/mock/rewards.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "name": "笔记本", "points": 50, "stock": 3, "img": "https://example.com/note.jpg" },
+  { "id": 2, "name": "水杯", "points": 80, "stock": 0, "img": "https://example.com/cup.jpg" }
+]

--- a/miniprogram/mock/user.json
+++ b/miniprogram/mock/user.json
@@ -1,0 +1,5 @@
+{
+  "openid": "mock",
+  "totalPoints": 200,
+  "history": []
+}

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -2,7 +2,7 @@ const app = getApp();
 
 Page({
   async handleStart() {
-    console.log("[tap]", Date.now());
+    console.log('[tap]', Date.now());
     try {
       const res = await wx.cloud.callFunction({ name: 'login' });
       app.globalData.openid = res.result.openid;

--- a/miniprogram/pages/profile/profile.js
+++ b/miniprogram/pages/profile/profile.js
@@ -1,16 +1,10 @@
+const { getUser } = require('../../utils/mockApi');
+
 Page({
   data: {
-    name: '',
-    studentId: '',
+    user: null,
   },
-  onNameChange(e) {
-    this.setData({ name: e.detail });
-  },
-  onIdChange(e) {
-    this.setData({ studentId: e.detail });
-  },
-  handleSubmit() {
-    wx.showToast({ title: '保存成功', icon: 'success' });
-    wx.navigateBack();
+  onShow() {
+    this.setData({ user: getUser() });
   },
 });

--- a/miniprogram/pages/profile/profile.json
+++ b/miniprogram/pages/profile/profile.json
@@ -1,9 +1,7 @@
 {
-  "navigationBarTitleText": "个人信息",
+  "navigationBarTitleText": "我的积分",
   "usingComponents": {
-
-    "van-field": "../../miniprogram_npm/@vant/weapp/field/index",
-    "van-button": "../../miniprogram_npm/@vant/weapp/button/index"
-
+    "van-cell": "../../miniprogram_npm/@vant/weapp/cell/index",
+    "van-empty": "../../miniprogram_npm/@vant/weapp/empty/index"
   }
 }

--- a/miniprogram/pages/profile/profile.wxml
+++ b/miniprogram/pages/profile/profile.wxml
@@ -1,7 +1,8 @@
-<form bindsubmit="handleSubmit">
-  <van-field label="姓名" value="{{name}}" bind:input="onNameChange" placeholder="请输入姓名" />
-  <van-field label="学号" value="{{studentId}}" bind:input="onIdChange" placeholder="请输入学号" />
-  <view class="btn-wrap">
-    <van-button block type="info" formType="submit">保存</van-button>
-  </view>
-</form>
+<view class="container">
+  <view class="point">剩余积分：{{user.totalPoints}}</view>
+  <view class="history-title">兑换记录</view>
+  <block wx:for="{{user.history}}" wx:key="index">
+    <van-cell title="{{item.name}}" label="{{item.points}}分" />
+  </block>
+  <van-empty wx:if="{{user.history.length===0}}" description="暂无记录" />
+</view>

--- a/miniprogram/pages/profile/profile.wxss
+++ b/miniprogram/pages/profile/profile.wxss
@@ -1,3 +1,10 @@
-.btn-wrap {
-  margin: 20rpx;
+.container {
+  padding: 40rpx;
+  text-align: center;
+}
+.point {
+  margin-bottom: 20rpx;
+}
+.history-title {
+  margin: 20rpx 0;
 }

--- a/miniprogram/pages/shop/shop.js
+++ b/miniprogram/pages/shop/shop.js
@@ -1,0 +1,18 @@
+const { getRewards, mockRedeem } = require('../../utils/mockApi');
+
+Page({
+  data: {
+    rewards: [],
+  },
+  onLoad() {
+    this.setData({ rewards: getRewards() });
+  },
+  handleRedeem(e) {
+    const id = Number(e.currentTarget.dataset.id);
+    const ok = mockRedeem(id);
+    if (ok) {
+      this.setData({ rewards: getRewards() });
+      wx.showToast({ title: '兑换成功' });
+    }
+  },
+});

--- a/miniprogram/pages/shop/shop.json
+++ b/miniprogram/pages/shop/shop.json
@@ -1,0 +1,7 @@
+{
+  "navigationBarTitleText": "积分兑换",
+  "usingComponents": {
+    "van-card": "../../miniprogram_npm/@vant/weapp/card/index",
+    "van-button": "../../miniprogram_npm/@vant/weapp/button/index"
+  }
+}

--- a/miniprogram/pages/shop/shop.wxml
+++ b/miniprogram/pages/shop/shop.wxml
@@ -1,0 +1,20 @@
+<view class="container">
+  <block wx:for="{{rewards}}" wx:key="id" class="card">
+    <van-card
+      thumb="{{item.img}}"
+      title="{{item.name}}"
+      desc="{{item.points}}\u79ef\u5206">
+      <view slot="footer">
+        <van-button
+          type="info"
+          size="small"
+          disabled="{{item.stock===0}}"
+          data-id="{{item.id}}"
+          bindtap="handleRedeem"
+        >
+          {{ item.stock===0 ? '已兑完' : '兑换' }}
+        </van-button>
+      </view>
+    </van-card>
+  </block>
+</view>

--- a/miniprogram/pages/shop/shop.wxss
+++ b/miniprogram/pages/shop/shop.wxss
@@ -1,0 +1,7 @@
+.container {
+  padding: 40rpx;
+  text-align: center;
+}
+.card + .card {
+  margin-top: 20rpx;
+}

--- a/miniprogram/utils/mockApi.js
+++ b/miniprogram/utils/mockApi.js
@@ -1,0 +1,25 @@
+const rewards = require('../mock/rewards.json');
+const user = require('../mock/user.json');
+
+function getRewards() {
+  return rewards;
+}
+
+function getUser() {
+  return user;
+}
+
+function mockRedeem(rewardId) {
+  const reward = rewards.find((r) => r.id === rewardId);
+  if (!reward || reward.stock <= 0) return false;
+  if (user.totalPoints < reward.points) {
+    wx.showToast({ title: '积分不足', icon: 'none' });
+    return false;
+  }
+  reward.stock -= 1;
+  user.totalPoints -= reward.points;
+  user.history.push({ id: reward.id, name: reward.name, points: reward.points });
+  return true;
+}
+
+module.exports = { getRewards, getUser, mockRedeem };


### PR DESCRIPTION
## Summary
- mock rewards and user data
- add mock API for redeeming rewards
- new shop page to redeem rewards
- overhaul profile page to show points and history
- tests for redeem logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d26a96b688320a8018d9ded1a899e