### PR TITLE
Add reward manager admin pages

### DIFF
--- a/__tests__/reward-mgr.test.js
+++ b/__tests__/reward-mgr.test.js
@@ -1,0 +1,159 @@
+/* eslint-disable no-underscore-dangle */
+const simulate = require('miniprogram-simulate');
+const { ADMIN_OPENIDS } = require('../miniprogram/common/constants');
+
+let mgrDef;
+let editDef;
+let originalPage;
+
+beforeAll(() => {
+  originalPage = global.Page;
+  global.Page = (obj) => { mgrDef = obj; };
+  // eslint-disable-next-line global-require
+  require('../miniprogram/pages/admin/reward-mgr/reward-mgr');
+  global.Page = (obj) => { editDef = obj; };
+  // eslint-disable-next-line global-require
+  require('../miniprogram/pages/admin/edit-reward/edit-reward');
+});
+
+afterAll(() => {
+  global.Page = originalPage;
+});
+
+global.getApp = () => ({ globalData: { openid: ADMIN_OPENIDS[0] } });
+
+const loadMgr = async () => {
+  const id = await simulate.load({
+    template: '<view></view>',
+    methods: {
+      onShow: mgrDef.onShow,
+      openAdd: mgrDef.openAdd,
+      closeAdd: mgrDef.closeAdd,
+      handleAdd: mgrDef.handleAdd,
+      handleNameChange: mgrDef.handleNameChange,
+      handlePointsChange: mgrDef.handlePointsChange,
+      handleStockChange: mgrDef.handleStockChange,
+    },
+    data: mgrDef.data,
+  });
+  const page = simulate.render(id);
+  page.attach(document.createElement('parent'));
+  return page;
+};
+
+const loadEdit = async () => {
+  const id = await simulate.load({
+    template: '<view></view>',
+    methods: {
+      onLoad: editDef.onLoad,
+      handleUpdate: editDef.handleUpdate,
+      handleDelete: editDef.handleDelete,
+      handlePointsChange: editDef.handlePointsChange,
+      handleStockChange: editDef.handleStockChange,
+    },
+    data: editDef.data,
+  });
+  const page = simulate.render(id);
+  page.attach(document.createElement('parent'));
+  return page;
+};
+
+test('add reward success', async () => {
+  const add = jest.fn().mockResolvedValue({ _id: 'n1' });
+  wx.cloud = {
+    database: () => ({
+      collection: () => ({
+        get: jest.fn().mockResolvedValue({ data: [] }),
+        add,
+      }),
+    }),
+  };
+  const page = await loadMgr();
+  await page.instance.onShow();
+  page.instance.handleNameChange({ detail: { value: 'A' } });
+  page.instance.handlePointsChange({ detail: { value: '1' } });
+  page.instance.handleStockChange({ detail: { value: '2' } });
+  await page.instance.handleAdd();
+  expect(add).toHaveBeenCalled();
+  expect(page.instance.data.rewards.length).toBe(1);
+});
+
+test('add reward fail', async () => {
+  const add = jest.fn().mockRejectedValue(new Error('fail'));
+  wx.cloud = {
+    database: () => ({
+      collection: () => ({
+        get: jest.fn().mockResolvedValue({ data: [] }),
+        add,
+      }),
+    }),
+  };
+  const page = await loadMgr();
+  await page.instance.onShow();
+  page.instance.handleNameChange({ detail: { value: 'A' } });
+  page.instance.handlePointsChange({ detail: { value: '1' } });
+  page.instance.handleStockChange({ detail: { value: '2' } });
+  await page.instance.handleAdd();
+  expect(page.instance.data.rewards.length).toBe(0);
+});
+
+test('update reward success', async () => {
+  const update = jest.fn().mockResolvedValue({});
+  const doc = {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        _id: 'r1',
+        name: 'A',
+        points: 1,
+        stock: 1,
+        img: '',
+      },
+    }),
+    update,
+    remove: jest.fn().mockResolvedValue({}),
+  };
+  wx.cloud = {
+    database: () => ({
+      collection: () => ({
+        doc: () => doc,
+      }),
+    }),
+  };
+  wx.navigateBack = jest.fn();
+  const page = await loadEdit();
+  await page.instance.onLoad({ id: 'r1' });
+  page.instance.handlePointsChange({ detail: { value: '5' } });
+  page.instance.handleStockChange({ detail: { value: '6' } });
+  await page.instance.handleUpdate();
+  expect(update).toHaveBeenCalled();
+});
+
+test('delete reward fail', async () => {
+  const remove = jest.fn().mockRejectedValue(new Error('fail'));
+  const doc = {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        _id: 'r1',
+        name: 'A',
+        points: 1,
+        stock: 1,
+        img: '',
+      },
+    }),
+    update: jest.fn().mockResolvedValue({}),
+    remove,
+  };
+  wx.cloud = {
+    database: () => ({
+      collection: () => ({
+        doc: () => doc,
+      }),
+    }),
+  };
+  wx.navigateBack = jest.fn();
+  const page = await loadEdit();
+  await page.instance.onLoad({ id: 'r1' });
+  await page.instance.handleDelete();
+  expect(remove).toHaveBeenCalled();
+  expect(wx.navigateBack).not.toHaveBeenCalled();
+});

--- a/cloudfunctions/rewardTrigger/index.js
+++ b/cloudfunctions/rewardTrigger/index.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-underscore-dangle */
+const cloud = require('wx-server-sdk');
+
+cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV });
+
+exports.main = async (event) => {
+  const { value } = event;
+  if (value && value.stock <= 5) {
+    // placeholder: send subscribe message
+    await cloud.callFunction({ name: 'notifyLowStock', data: { id: value._id } });
+  }
+  return {};
+};

--- a/cloudfunctions/rewardTrigger/package.json
+++ b/cloudfunctions/rewardTrigger/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rewardTrigger",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "wx-server-sdk": "^3.0.1"
+  },
+  "triggers": [
+    {
+      "name": "RewardsTrigger",
+      "type": "database",
+      "config": {
+        "collection": "Rewards",
+        "operation": "update",
+        "fullDocument": "default"
+      }
+    }
+  ]
+}

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -7,6 +7,8 @@
     "pages/log-time/log-time",
     "pages/admin/audit/audit",
     "pages/admin/stats/stats",
+    "pages/admin/reward-mgr/reward-mgr",
+    "pages/admin/edit-reward/edit-reward",
     "pages/history/history"
   ],
   "window": {

--- a/miniprogram/miniprogram_npm/@vant/weapp/skeleton/index.js
+++ b/miniprogram/miniprogram_npm/@vant/weapp/skeleton/index.js
@@ -1,0 +1,1 @@
+Component({});

--- a/miniprogram/miniprogram_npm/@vant/weapp/skeleton/index.json
+++ b/miniprogram/miniprogram_npm/@vant/weapp/skeleton/index.json
@@ -1,0 +1,4 @@
+{
+  "component": true,
+  "usingComponents": {}
+}

--- a/miniprogram/miniprogram_npm/@vant/weapp/skeleton/index.wxml
+++ b/miniprogram/miniprogram_npm/@vant/weapp/skeleton/index.wxml
@@ -1,0 +1,1 @@
+<view class="van-skeleton"></view>

--- a/miniprogram/pages/admin/audit/audit.js
+++ b/miniprogram/pages/admin/audit/audit.js
@@ -1,16 +1,17 @@
 const { ADMIN_OPENIDS, LOG_STATUS } = require('../../common/constants');
 
 Page({
-  data: { logs: [] },
+  data: { logs: [], loading: true },
   async onShow() {
     const { openid } = getApp().globalData;
     if (!ADMIN_OPENIDS.includes(openid)) {
       wx.navigateBack();
       return;
     }
+    this.setData({ loading: true });
     const db = wx.cloud.database();
     const res = await db.collection('Logs').where({ status: LOG_STATUS.PENDING }).get();
-    this.setData({ logs: res.data });
+    this.setData({ logs: res.data, loading: false });
   },
   async handleApprove(e) {
     const { id } = e.currentTarget.dataset;

--- a/miniprogram/pages/admin/audit/audit.json
+++ b/miniprogram/pages/admin/audit/audit.json
@@ -3,6 +3,7 @@
   "usingComponents": {
     "van-button": "../../../miniprogram_npm/@vant/weapp/button/index",
     "van-cell": "../../../miniprogram_npm/@vant/weapp/cell/index",
-    "van-empty": "../../../miniprogram_npm/@vant/weapp/empty/index"
+    "van-empty": "../../../miniprogram_npm/@vant/weapp/empty/index",
+    "van-skeleton": "../../../miniprogram_npm/@vant/weapp/skeleton/index"
   }
 }

--- a/miniprogram/pages/admin/audit/audit.wxml
+++ b/miniprogram/pages/admin/audit/audit.wxml
@@ -1,8 +1,11 @@
 <view>
-  <block wx:for="{{logs}}" wx:key="_id">
-    <van-cell title="{{item.type}}" label="{{item.minutes}}分钟">
-      <van-button data-id="{{item._id}}" bindtap="handleApprove" type="primary" size="small">通过</van-button>
-    </van-cell>
+  <van-skeleton wx:if="{{loading}}" row="3" />
+  <block wx:if="{{!loading}}">
+    <block wx:for="{{logs}}" wx:key="_id">
+      <van-cell title="{{item.type}}" label="{{item.minutes}}分钟">
+        <van-button data-id="{{item._id}}" bindtap="handleApprove" type="primary" size="small">通过</van-button>
+      </van-cell>
+    </block>
+    <van-empty wx:if="{{logs.length===0}}" description="暂无待审核" />
   </block>
-  <van-empty wx:if="{{logs.length===0}}" description="暂无待审核" />
 </view>

--- a/miniprogram/pages/admin/edit-reward/edit-reward.js
+++ b/miniprogram/pages/admin/edit-reward/edit-reward.js
@@ -1,0 +1,63 @@
+const { ADMIN_OPENIDS } = require('../../common/constants');
+const { updateReward, deleteReward, uploadImage } = require('../../../utils/cloudApi');
+
+Page({
+  data: {
+    id: '',
+    name: '',
+    points: 0,
+    stock: 0,
+    img: '',
+  },
+  async onLoad(options) {
+    const { openid } = getApp().globalData;
+    if (!ADMIN_OPENIDS.includes(openid)) {
+      wx.navigateBack();
+      return;
+    }
+    const { id } = options;
+    this.setData({ id });
+    try {
+      const db = wx.cloud.database();
+      const res = await db.collection('Rewards').doc(id).get();
+      this.setData(res.data);
+    } catch (e) {
+      // ignore
+    }
+  },
+  handlePointsChange(e) {
+    this.setData({ points: Number(e.detail.value) });
+  },
+  handleStockChange(e) {
+    this.setData({ stock: Number(e.detail.value) });
+  },
+  async handleChooseImage() {
+    try {
+      const choose = await wx.chooseImage({ count: 1 });
+      const { fileID } = await uploadImage(choose.tempFilePaths[0]);
+      this.setData({ img: fileID });
+    } catch (e) {
+      // ignore
+    }
+  },
+  async handleUpdate() {
+    try {
+      await updateReward(this.data.id, {
+        points: this.data.points,
+        stock: this.data.stock,
+        img: this.data.img,
+      });
+      wx.navigateBack();
+    } catch (e) {
+      // ignore
+    }
+  },
+  async handleDelete() {
+    try {
+      await deleteReward(this.data.id);
+      wx.navigateBack();
+    } catch (e) {
+      // ignore
+    }
+  },
+});

--- a/miniprogram/pages/admin/edit-reward/edit-reward.json
+++ b/miniprogram/pages/admin/edit-reward/edit-reward.json
@@ -1,0 +1,8 @@
+{
+  "navigationBarTitleText": "编辑奖品",
+  "usingComponents": {
+    "van-field": "../../../miniprogram_npm/@vant/weapp/field/index",
+    "van-button": "../../../miniprogram_npm/@vant/weapp/button/index",
+    "van-dialog": "../../../miniprogram_npm/@vant/weapp/dialog/index"
+  }
+}

--- a/miniprogram/pages/admin/edit-reward/edit-reward.wxml
+++ b/miniprogram/pages/admin/edit-reward/edit-reward.wxml
@@ -1,0 +1,8 @@
+<view class="container">
+  <van-field label="积分" type="number" value="{{points}}" bind:input="handlePointsChange" />
+  <van-field label="库存" type="number" value="{{stock}}" bind:input="handleStockChange" />
+  <van-button type="primary" bindtap="handleChooseImage">选择图片</van-button>
+  <image wx:if="{{img}}" src="{{img}}" class="img" />
+  <van-button type="info" bindtap="handleUpdate">保存</van-button>
+  <van-button type="danger" bindtap="handleDelete">删除</van-button>
+</view>

--- a/miniprogram/pages/admin/edit-reward/edit-reward.wxss
+++ b/miniprogram/pages/admin/edit-reward/edit-reward.wxss
@@ -1,0 +1,8 @@
+.container {
+  padding: 40rpx;
+}
+.img {
+  width: 100rpx;
+  height: 100rpx;
+  margin-top: 20rpx;
+}

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.js
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-underscore-dangle */
+const { ADMIN_OPENIDS } = require('../../common/constants');
+const { addReward } = require('../../../utils/cloudApi');
+
+Page({
+  data: {
+    rewards: [],
+    showAdd: false,
+    name: '',
+    points: 0,
+    stock: 0,
+  },
+  async onShow() {
+    const { openid } = getApp().globalData;
+    if (!ADMIN_OPENIDS.includes(openid)) {
+      wx.navigateBack();
+      return;
+    }
+    try {
+      const db = wx.cloud.database();
+      const res = await db.collection('Rewards').get();
+      this.setData({ rewards: res.data });
+    } catch (e) {
+      // ignore
+    }
+  },
+  openAdd() {
+    this.setData({
+      showAdd: true,
+      name: '',
+      points: 0,
+      stock: 0,
+    });
+  },
+  closeAdd() {
+    this.setData({ showAdd: false });
+  },
+  handleNameChange(e) {
+    this.setData({ name: e.detail.value });
+  },
+  handlePointsChange(e) {
+    this.setData({ points: Number(e.detail.value) });
+  },
+  handleStockChange(e) {
+    this.setData({ stock: Number(e.detail.value) });
+  },
+  async handleAdd() {
+    try {
+      const res = await addReward({
+        name: this.data.name,
+        points: this.data.points,
+        stock: this.data.stock,
+        img: '',
+      });
+      this.setData({
+        rewards: this.data.rewards.concat([
+          {
+            _id: res._id,
+            name: this.data.name,
+            points: this.data.points,
+            stock: this.data.stock,
+            img: '',
+          },
+        ]),
+        showAdd: false,
+      });
+    } catch (e) {
+      // ignore
+    }
+  },
+  handleEdit(e) {
+    const { id } = e.currentTarget.dataset;
+    wx.navigateTo({ url: `/pages/admin/edit-reward/edit-reward?id=${id}` });
+  },
+});

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.js
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.js
@@ -5,6 +5,7 @@ const { addReward } = require('../../../utils/cloudApi');
 Page({
   data: {
     rewards: [],
+    loading: true,
     showAdd: false,
     name: '',
     points: 0,
@@ -16,6 +17,7 @@ Page({
       wx.navigateBack();
       return;
     }
+    this.setData({ loading: true });
     try {
       const db = wx.cloud.database();
       const res = await db.collection('Rewards').get();
@@ -23,6 +25,7 @@ Page({
     } catch (e) {
       // ignore
     }
+    this.setData({ loading: false });
   },
   openAdd() {
     this.setData({

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.json
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.json
@@ -1,0 +1,9 @@
+{
+  "navigationBarTitleText": "奖品管理",
+  "usingComponents": {
+    "van-button": "../../../miniprogram_npm/@vant/weapp/button/index",
+    "van-card": "../../../miniprogram_npm/@vant/weapp/card/index",
+    "van-dialog": "../../../miniprogram_npm/@vant/weapp/dialog/index",
+    "van-field": "../../../miniprogram_npm/@vant/weapp/field/index"
+  }
+}

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.json
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.json
@@ -4,6 +4,8 @@
     "van-button": "../../../miniprogram_npm/@vant/weapp/button/index",
     "van-card": "../../../miniprogram_npm/@vant/weapp/card/index",
     "van-dialog": "../../../miniprogram_npm/@vant/weapp/dialog/index",
-    "van-field": "../../../miniprogram_npm/@vant/weapp/field/index"
+    "van-field": "../../../miniprogram_npm/@vant/weapp/field/index",
+    "van-empty": "../../../miniprogram_npm/@vant/weapp/empty/index",
+    "van-skeleton": "../../../miniprogram_npm/@vant/weapp/skeleton/index"
   }
 }

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.wxml
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.wxml
@@ -1,13 +1,17 @@
 <view class="container">
   <van-button type="info" bindtap="openAdd">新增奖品</van-button>
-  <block wx:for="{{rewards}}" wx:key="_id" class="card">
-    <van-card
-      thumb="{{item.img}}"
-      title="{{item.name}}"
-      desc="{{item.points}}积分 库存{{item.stock}}"
-      data-id="{{item._id}}"
-      bindtap="handleEdit"
-    />
+  <van-skeleton wx:if="{{loading}}" row="3" />
+  <block wx:if="{{!loading}}">
+    <block wx:for="{{rewards}}" wx:key="_id" class="card">
+      <van-card
+        thumb="{{item.img}}"
+        title="{{item.name}}"
+        desc="{{item.points}}积分 库存{{item.stock}}"
+        data-id="{{item._id}}"
+        bindtap="handleEdit"
+      />
+    </block>
+    <van-empty wx:if="{{rewards.length===0}}" description="暂无奖品" />
   </block>
   <van-dialog
     title="新增奖品"

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.wxml
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.wxml
@@ -1,0 +1,25 @@
+<view class="container">
+  <van-button type="info" bindtap="openAdd">新增奖品</van-button>
+  <block wx:for="{{rewards}}" wx:key="_id" class="card">
+    <van-card
+      thumb="{{item.img}}"
+      title="{{item.name}}"
+      desc="{{item.points}}积分 库存{{item.stock}}"
+      data-id="{{item._id}}"
+      bindtap="handleEdit"
+    />
+  </block>
+  <van-dialog
+    title="新增奖品"
+    show="{{showAdd}}"
+    show-cancel
+    bind:close="closeAdd"
+    bind:confirm="handleAdd"
+  >
+    <view>
+      <van-field placeholder="名称" bind:input="handleNameChange" value="{{name}}" />
+      <van-field type="number" placeholder="积分" bind:input="handlePointsChange" value="{{points}}" />
+      <van-field type="number" placeholder="库存" bind:input="handleStockChange" value="{{stock}}" />
+    </view>
+  </van-dialog>
+</view>

--- a/miniprogram/pages/admin/reward-mgr/reward-mgr.wxss
+++ b/miniprogram/pages/admin/reward-mgr/reward-mgr.wxss
@@ -1,0 +1,6 @@
+.container {
+  padding: 40rpx;
+}
+.card + .card {
+  margin-top: 20rpx;
+}

--- a/miniprogram/pages/admin/stats/stats.js
+++ b/miniprogram/pages/admin/stats/stats.js
@@ -13,13 +13,23 @@ Page({
     }
     const res = await wx.cloud.callFunction({ name: 'getStats' });
     const { laborMinutes, volunteerMinutes } = res.result;
+    const total = laborMinutes + volunteerMinutes;
     // eslint-disable-next-line no-new, new-cap
     new wxCharts({
       canvasId: 'pieCanvas',
       type: 'pie',
+      legend: true,
       series: [
-        { name: '劳动', data: laborMinutes },
-        { name: '志愿', data: volunteerMinutes },
+        {
+          name: `劳动 ${((laborMinutes / total) * 100).toFixed(0)}%`,
+          data: laborMinutes,
+          color: '#4CAF50',
+        },
+        {
+          name: `志愿 ${((volunteerMinutes / total) * 100).toFixed(0)}%`,
+          data: volunteerMinutes,
+          color: '#2196F3',
+        },
       ],
       width: 300,
       height: 200,

--- a/miniprogram/pages/history/history.js
+++ b/miniprogram/pages/history/history.js
@@ -1,8 +1,10 @@
 Page({
   data: {
     logs: [],
+    loading: true,
   },
   async onShow() {
+    this.setData({ loading: true });
     try {
       const db = wx.cloud.database();
       const { openid } = getApp().globalData;
@@ -14,5 +16,6 @@ Page({
     } catch (e) {
       // ignore fetch failure
     }
+    this.setData({ loading: false });
   },
 });

--- a/miniprogram/pages/history/history.json
+++ b/miniprogram/pages/history/history.json
@@ -2,6 +2,7 @@
   "navigationBarTitleText": "记录",
   "usingComponents": {
     "van-cell": "../../miniprogram_npm/@vant/weapp/cell/index",
-    "van-empty": "../../miniprogram_npm/@vant/weapp/empty/index"
+    "van-empty": "../../miniprogram_npm/@vant/weapp/empty/index",
+    "van-skeleton": "../../miniprogram_npm/@vant/weapp/skeleton/index"
   }
 }

--- a/miniprogram/pages/history/history.wxml
+++ b/miniprogram/pages/history/history.wxml
@@ -1,9 +1,12 @@
 <view>
-  <block wx:for="{{logs}}" wx:key="_id">
-    <van-cell
-      title="{{item.type}}"
-      label="{{item.minutes}}\u5206\u949f - {{item.status}} {{item.remark}}"
-    />
+  <van-skeleton wx:if="{{loading}}" row="3" />
+  <block wx:if="{{!loading}}">
+    <block wx:for="{{logs}}" wx:key="_id">
+      <van-cell
+        title="{{item.type}}"
+        label="{{item.minutes}}分钟 - {{item.status}} {{item.remark}}"
+      />
+    </block>
+    <van-empty wx:if="{{logs.length===0}}" description="暂无记录" />
   </block>
-  <van-empty wx:if="{{logs.length===0}}" description="\u6682\u65e0\u8bb0\u5f55" />
 </view>

--- a/miniprogram/pages/home/home.js
+++ b/miniprogram/pages/home/home.js
@@ -1,8 +1,17 @@
+const { getUser } = require('../../utils/mockApi');
+
 Page({
-  goProfile() {
-    wx.navigateTo({ url: '/pages/profile/profile' });
+  data: {
+    totalPoints: 0,
   },
-  goLogTime() {
+  onShow() {
+    const user = getUser();
+    this.setData({ totalPoints: user.totalPoints });
+  },
+  goSubmit() {
     wx.navigateTo({ url: '/pages/log-time/log-time' });
+  },
+  goRedeem() {
+    wx.navigateTo({ url: '/pages/shop/shop' });
   },
 });

--- a/miniprogram/pages/home/home.wxml
+++ b/miniprogram/pages/home/home.wxml
@@ -1,8 +1,7 @@
 <view class="container">
-
-  <van-card>欢迎使用善水书院积分系统</van-card>
+  <van-card title="我的积分" desc="{{totalPoints}} 分"></van-card>
   <view class="btn-wrap">
-    <van-button type="primary" block bindtap="goProfile">个人信息</van-button>
-    <van-button type="info" block bindtap="goLogTime">时长提交</van-button>
+    <van-button type="primary" block bindtap="goSubmit">去提交</van-button>
+    <van-button type="info" block bindtap="goRedeem">去兑换</van-button>
   </view>
 </view>

--- a/miniprogram/pages/home/home.wxss
+++ b/miniprogram/pages/home/home.wxss
@@ -1,6 +1,13 @@
+
+page {
+  height: 100%;
+  display: flex;
+}
+
 .container {
   padding: 40rpx;
   text-align: center;
+  margin: auto;
 }
 
 .btn-wrap {

--- a/miniprogram/pages/profile/profile.js
+++ b/miniprogram/pages/profile/profile.js
@@ -3,8 +3,9 @@ const { getUser } = require('../../utils/mockApi');
 Page({
   data: {
     user: null,
+    loading: true,
   },
   onShow() {
-    this.setData({ user: getUser() });
+    this.setData({ user: getUser(), loading: false });
   },
 });

--- a/miniprogram/pages/profile/profile.json
+++ b/miniprogram/pages/profile/profile.json
@@ -2,6 +2,7 @@
   "navigationBarTitleText": "我的积分",
   "usingComponents": {
     "van-cell": "../../miniprogram_npm/@vant/weapp/cell/index",
-    "van-empty": "../../miniprogram_npm/@vant/weapp/empty/index"
+    "van-empty": "../../miniprogram_npm/@vant/weapp/empty/index",
+    "van-skeleton": "../../miniprogram_npm/@vant/weapp/skeleton/index"
   }
 }

--- a/miniprogram/pages/profile/profile.wxml
+++ b/miniprogram/pages/profile/profile.wxml
@@ -1,8 +1,11 @@
 <view class="container">
-  <view class="point">剩余积分：{{user.totalPoints}}</view>
-  <view class="history-title">兑换记录</view>
-  <block wx:for="{{user.history}}" wx:key="index">
-    <van-cell title="{{item.name}}" label="{{item.points}}分" />
+  <van-skeleton wx:if="{{loading}}" row="3" />
+  <block wx:if="{{!loading}}">
+    <view class="point">剩余积分：{{user.totalPoints}}</view>
+    <view class="history-title">兑换记录</view>
+    <block wx:for="{{user.history}}" wx:key="index">
+      <van-cell title="{{item.name}}" label="{{item.points}}分" />
+    </block>
+    <van-empty wx:if="{{user.history.length===0}}" description="暂无记录" />
   </block>
-  <van-empty wx:if="{{user.history.length===0}}" description="暂无记录" />
 </view>

--- a/miniprogram/pages/shop/shop.js
+++ b/miniprogram/pages/shop/shop.js
@@ -3,9 +3,10 @@ const { getRewards, mockRedeem } = require('../../utils/mockApi');
 Page({
   data: {
     rewards: [],
+    loading: true,
   },
   onLoad() {
-    this.setData({ rewards: getRewards() });
+    this.setData({ rewards: getRewards(), loading: false });
   },
   handleRedeem(e) {
     const id = Number(e.currentTarget.dataset.id);

--- a/miniprogram/pages/shop/shop.json
+++ b/miniprogram/pages/shop/shop.json
@@ -2,6 +2,8 @@
   "navigationBarTitleText": "积分兑换",
   "usingComponents": {
     "van-card": "../../miniprogram_npm/@vant/weapp/card/index",
-    "van-button": "../../miniprogram_npm/@vant/weapp/button/index"
+    "van-button": "../../miniprogram_npm/@vant/weapp/button/index",
+    "van-empty": "../../miniprogram_npm/@vant/weapp/empty/index",
+    "van-skeleton": "../../miniprogram_npm/@vant/weapp/skeleton/index"
   }
 }

--- a/miniprogram/pages/shop/shop.wxml
+++ b/miniprogram/pages/shop/shop.wxml
@@ -1,20 +1,25 @@
 <view class="container">
-  <block wx:for="{{rewards}}" wx:key="id" class="card">
-    <van-card
-      thumb="{{item.img}}"
-      title="{{item.name}}"
-      desc="{{item.points}}\u79ef\u5206">
-      <view slot="footer">
-        <van-button
-          type="info"
-          size="small"
-          disabled="{{item.stock===0}}"
-          data-id="{{item.id}}"
-          bindtap="handleRedeem"
-        >
-          {{ item.stock===0 ? '已兑完' : '兑换' }}
-        </van-button>
-      </view>
-    </van-card>
+  <van-skeleton wx:if="{{loading}}" row="3" />
+  <block wx:if="{{!loading}}">
+    <block wx:for="{{rewards}}" wx:key="id" class="card">
+      <van-card
+        thumb="{{item.img}}"
+        title="{{item.name}}"
+        desc="{{item.points}}积分"
+      >
+        <view slot="footer">
+          <van-button
+            type="info"
+            size="small"
+            disabled="{{item.stock===0}}"
+            data-id="{{item.id}}"
+            bindtap="handleRedeem"
+          >
+            {{ item.stock===0 ? '已兑完' : '兑换' }}
+          </van-button>
+        </view>
+      </van-card>
+    </block>
+    <van-empty wx:if="{{rewards.length===0}}" description="暂无奖品" />
   </block>
 </view>

--- a/miniprogram/utils/cloudApi.js
+++ b/miniprogram/utils/cloudApi.js
@@ -1,0 +1,28 @@
+function addReward(data) {
+  const db = wx.cloud.database();
+  return db.collection('Rewards').add({ data });
+}
+
+function updateReward(id, data) {
+  const db = wx.cloud.database();
+  return db.collection('Rewards').doc(id).update({ data });
+}
+
+function deleteReward(id) {
+  const db = wx.cloud.database();
+  return db.collection('Rewards').doc(id).remove();
+}
+
+function uploadImage(filePath) {
+  return wx.cloud.uploadFile({
+    cloudPath: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    filePath,
+  });
+}
+
+module.exports = {
+  addReward,
+  updateReward,
+  deleteReward,
+  uploadImage,
+};


### PR DESCRIPTION
## Summary
- add cloudApi utility for reward operations
- implement reward manager pages with add/edit/delete
- create reward low stock database trigger
- add tests for reward management

## Testing
- `npx eslint .`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d2a9b35fc8320b7ea4f15c4571c04